### PR TITLE
Fix HLSL semantics of matrix attributes

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -789,6 +789,7 @@ void *SDL_ShaderCross_CompileFromSPIRV(
     if (backend == SPVC_BACKEND_HLSL) {
         SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL, shadermodel);
         SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_NONWRITABLE_UAV_TEXTURE_AS_SRV, 1);
+        SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS, 1);
     }
 
     result = SDL_spvc_compiler_install_compiler_options(compiler, options);


### PR DESCRIPTION
Matrix attributes are well-defined to consume multiple locations in glsl:

```glsl
#version 450

layout(location = 0) in mat4 a_mat4;   // consumes locations 0-3

layout(location = 0) out mat4 o_mat4;

void main() {
    o_mat4 = a_mat4;
}
```
By default, SPIRV-Cross translates this into:
```hlsl
static float4x4 o_mat4;
static float4x4 a_mat4;

struct SPIRV_Cross_Input
{
    float4 a_mat4_0 : TEXCOORD0_0;
    float4 a_mat4_1 : TEXCOORD0_1;
    float4 a_mat4_2 : TEXCOORD0_2;
    float4 a_mat4_3 : TEXCOORD0_3;
};

struct SPIRV_Cross_Output
{
    float4x4 o_mat4 : TEXCOORD0;
};

void vert_main()
{
    o_mat4 = a_mat4;
}

SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
{
    a_mat4[0] = stage_input.a_mat4_0;
    a_mat4[1] = stage_input.a_mat4_1;
    a_mat4[2] = stage_input.a_mat4_2;
    a_mat4[3] = stage_input.a_mat4_3;
    vert_main();
    SPIRV_Cross_Output stage_output;
    stage_output.o_mat4 = o_mat4;
    return stage_output;
}
```

The semantic strings here are not compatible with SDL_GPU's expectations. This patch fixes that, making it output
```hlsl
struct SPIRV_Cross_Input
{
    float4 a_mat4_0 : TEXCOORD0;
    float4 a_mat4_1 : TEXCOORD1;
    float4 a_mat4_2 : TEXCOORD2;
    float4 a_mat4_3 : TEXCOORD3;
};
```

This is equivalent to the `--hlsl-flatten-matrix-vertex-input-semantics` flag in the CLI frontend.