### PR TITLE
Fix scrambled sampler order in some SPIRV->MSL cases

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -790,6 +790,8 @@ void *SDL_ShaderCross_CompileFromSPIRV(
         SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_SHADER_MODEL, shadermodel);
         SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_NONWRITABLE_UAV_TEXTURE_AS_SRV, 1);
         SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_HLSL_FLATTEN_MATRIX_VERTEX_INPUT_SEMANTICS, 1);
+    } else if (backend == SPVC_BACKEND_MSL) {
+        SDL_spvc_compiler_options_set_uint(options, SPVC_COMPILER_OPTION_MSL_ENABLE_DECORATION_BINDING, 1);
     }
 
     result = SDL_spvc_compiler_install_compiler_options(compiler, options);


### PR DESCRIPTION
By default, when translating into MSL SPIRV-Cross ignores binding decorations on samplers and assigns indices in the order the samplers appear in the SPIR-V, which can be arbitrary and not even match the declaration order in the source file.

Consider this glsl shader:

```glsl
#version 450

layout(location = 0) in vec2 uv;

layout(location = 0) out vec4 color;

layout(binding = 0) uniform sampler2D reimu;
layout(binding = 1) uniform sampler2D marisa;
layout(binding = 2) uniform sampler2D yukari;
layout(binding = 3) uniform sampler2D yuyuko;
layout(binding = 4) uniform sampler2D youmu;

void main() {
    color = texture(reimu, uv) * texture(marisa, uv) * texture(youmu, uv) * texture(yukari, uv) * texture(yuyuko, uv);
}
```

If we compile this with glslang and translate it back into glsl with SPIRV-Cross, we can see that the declaration order is not preserved:
```glsl
#version 450

layout(binding = 0) uniform sampler2D reimu;
layout(binding = 1) uniform sampler2D marisa;
layout(binding = 4) uniform sampler2D youmu;
layout(binding = 2) uniform sampler2D yukari;
layout(binding = 3) uniform sampler2D yuyuko;

layout(location = 0) out vec4 color;
layout(location = 0) in vec2 uv;

void main()
{
    color = (((texture(reimu, uv) * texture(marisa, uv)) * texture(youmu, uv)) * texture(yukari, uv)) * texture(yuyuko, uv);
}
```

Translating it into MSL produces: 

```metal
#include <metal_stdlib>
#include <simd/simd.h>

using namespace metal;

struct main0_out
{
    float4 color [[color(0)]];
};

struct main0_in
{
    float2 uv [[user(locn0)]];
};

fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> reimu [[texture(0)]], texture2d<float> marisa [[texture(1)]], texture2d<float> youmu [[texture(2)]], texture2d<float> yukari [[texture(3)]], texture2d<float> yuyuko [[texture(4)]], sampler reimuSmplr [[sampler(0)]], sampler marisaSmplr [[sampler(1)]], sampler youmuSmplr [[sampler(2)]], sampler yukariSmplr [[sampler(3)]], sampler yuyukoSmplr [[sampler(4)]])
{
    main0_out out = {};
    out.color = (((reimu.sample(reimuSmplr, in.uv) * marisa.sample(marisaSmplr, in.uv)) * youmu.sample(youmuSmplr, in.uv)) * yukari.sample(yukariSmplr, in.uv)) * yuyuko.sample(yuyukoSmplr, in.uv);
    return out;
}
```

We can see that the assigned indices do not match the binding decorations. Enabling `SPVC_COMPILER_OPTION_MSL_ENABLE_DECORATION_BINDING` fixes this:

```metal
fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> reimu [[texture(0)]], texture2d<float> marisa [[texture(1)]], texture2d<float> yukari [[texture(2)]], texture2d<float> yuyuko [[texture(3)]], texture2d<float> youmu [[texture(4)]], sampler reimuSmplr [[sampler(0)]], sampler marisaSmplr [[sampler(1)]], sampler yukariSmplr [[sampler(2)]], sampler yuyukoSmplr [[sampler(3)]], sampler youmuSmplr [[sampler(4)]])
```

This is equivalent to the `--msl-decoration-binding` flag in the CLI frontend. `--help` has this to say about it:

```
	[--msl-decoration-binding]:
		Use SPIR-V bindings directly as MSL bindings.
		This does not work in the general case as there is no descriptor set support, and combined image samplers are split up.
		However, if the shader author knows of binding limitations, this option will avoid the need for reflection on Metal side.
```

So far the only types of resources I've used in my shaders have been samplers and a single uniform buffer per shader. I'm not sure how storage textures and storage buffers play into this.