### PR TITLE
Add ability to specify export prefix for symbols

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -32,6 +32,10 @@
 #define SDL_GPU_SHADERCROSS_HLSL 1
 #endif /* SDL_GPU_SHADERCROSS_HLSL */
 
+#ifndef SDL_GPU_SHADERCROSS_EXPORT
+#define SDL_GPU_SHADERCROSS_EXPORT
+#endif
+
 /**
  * Initializes SDL_gpu_shadercross
  *
@@ -662,7 +666,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromHLSL(SDL_GPUDevice *device,
     return NULL;
 }
 
-SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromHLSL(
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromHLSL(
     SDL_GPUDevice *device,
     const SDL_GPUShaderCreateInfo *createInfo,
     const char *hlslSource,
@@ -671,7 +675,7 @@ SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromHLSL(
     return (SDL_GPUShader *)SDL_ShaderCross_INTERNAL_CompileFromHLSL(device, createInfo, hlslSource, shaderProfile);
 }
 
-SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromHLSL(
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromHLSL(
     SDL_GPUDevice *device,
     const SDL_GPUComputePipelineCreateInfo *createInfo,
     const char *hlslSource,
@@ -904,14 +908,14 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
     return compiledResult;
 }
 
-SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(
     SDL_GPUDevice *device,
     const SDL_GPUShaderCreateInfo *createInfo)
 {
     return (SDL_GPUShader *)SDL_ShaderCross_INTERNAL_CompileFromSPIRV(device, createInfo, false);
 }
 
-SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromSPIRV(
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromSPIRV(
     SDL_GPUDevice *device,
     const SDL_GPUComputePipelineCreateInfo *createInfo)
 {
@@ -920,7 +924,7 @@ SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromSPIRV(
 
 #endif /* SDL_GPU_SHADERCROSS_SPIRVCROSS */
 
-bool SDL_ShaderCross_Init(void)
+SDL_GPU_SHADERCROSS_EXPORT bool SDL_ShaderCross_Init(void)
 {
     dxcompiler_dll = SDL_LoadObject(DXCOMPILER_DLL);
     if (dxcompiler_dll != NULL) {
@@ -997,7 +1001,7 @@ bool SDL_ShaderCross_Init(void)
     return true;
 }
 
-void SDL_ShaderCross_Quit(void)
+SDL_GPU_SHADERCROSS_EXPORT void SDL_ShaderCross_Quit(void)
 {
 #ifdef SDL_GPU_SHADERCROSS_SPIRV
 #ifndef SDL_GPU_SHADERCROSS_STATIC
@@ -1039,7 +1043,7 @@ void SDL_ShaderCross_Quit(void)
 
 #ifdef SDL_GPU_SHADERCROSS_SPIRVCROSS
 
-SDL_GPUShaderFormat SDL_ShaderCross_GetSPIRVShaderFormats(void)
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUShaderFormat SDL_ShaderCross_GetSPIRVShaderFormats(void)
 {
     /* SPIRV can always be output as-is with no preprocessing */
     SDL_GPUShaderFormat supportedFormats = SDL_GPU_SHADERFORMAT_SPIRV;
@@ -1074,7 +1078,7 @@ SDL_GPUShaderFormat SDL_ShaderCross_GetSPIRVShaderFormats(void)
 
 #if SDL_GPU_SHADERCROSS_HLSL
 
-SDL_GPUShaderFormat SDL_ShaderCross_GetHLSLShaderFormats(void)
+SDL_GPU_SHADERCROSS_EXPORT SDL_GPUShaderFormat SDL_ShaderCross_GetHLSLShaderFormats(void)
 {
     SDL_GPUShaderFormat supportedFormats = 0;
 


### PR DESCRIPTION
This is required to build a standalone library of SDL_gpu_shadercross on Windows, where the linker will only export the symbol if it has the `__declspec(dllexport)` attribute.

Since using it as a standalone library isn't the default usecase of the lib, I've left it blank by default, with the ability to set it through putting `#define SDL_GPU_SHADERCROSS_EXPORT __declspec(dllexport)` before the header's implementation