### PR TITLE
Fix segfault when D3DCompile is not found

### DIFF
--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -560,6 +560,11 @@ static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
     ID3DBlob *errorBlob;
     HRESULT ret;
 
+    if (SDL_D3DCompile == NULL) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "Could not load D3DCompile!");
+        return NULL;
+    }
+
     ret = SDL_D3DCompile(
         hlslSource,
         SDL_strlen(hlslSource),


### PR DESCRIPTION
Resolves #32 