### PR TITLE
Add METALLIB output support for the CLI

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -22,6 +22,7 @@
 #include <SDL3_gpu_shadercross/SDL_gpu_shadercross.h>
 #include <SDL3/SDL_log.h>
 #include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_process.h>
 
 // We can emit HLSL as a destination, so let's redefine the shader format enum.
 typedef enum ShaderCross_DestinationFormat {
@@ -30,8 +31,17 @@ typedef enum ShaderCross_DestinationFormat {
     SHADERFORMAT_DXBC,
     SHADERFORMAT_DXIL,
     SHADERFORMAT_MSL,
-    SHADERFORMAT_HLSL
+    SHADERFORMAT_METALLIB,
+    SHADERFORMAT_HLSL,
 } ShaderCross_ShaderFormat;
+
+typedef enum ShaderCross_Platform {
+    PLATFORM_METAL_MACOS,
+    PLATFORM_METAL_IOS,
+} ShaderCross_Platform;
+
+bool check_for_metal_tools(void);
+int compile_metallib(ShaderCross_Platform platform, const char *outputFilename);
 
 void print_help(void)
 {
@@ -39,10 +49,11 @@ void print_help(void)
     SDL_Log("Usage: shadercross <input> [options]");
     SDL_Log("Required options:\n");
     SDL_Log("  %-*s %s", column_width, "-s | --source <value>", "Source language format. May be inferred from the filename. Values: [SPIRV, HLSL]");
-    SDL_Log("  %-*s %s", column_width, "-d | --dest <value>", "Destination format. May be inferred from the filename. Values: [DXBC, DXIL, MSL, SPIRV, HLSL]");
+    SDL_Log("  %-*s %s", column_width, "-d | --dest <value>", "Destination format. May be inferred from the filename. Values: [SPIRV, DXBC, DXIL, MSL, METALLIB, HLSL]");
     SDL_Log("  %-*s %s", column_width, "-t | --stage <value>", "Shader stage. May be inferred from the filename. Values: [vertex, fragment, compute]");
     SDL_Log("  %-*s %s", column_width, "-e | --entrypoint <value>", "Entrypoint function name. Default: \"main\".");
     SDL_Log("  %-*s %s", column_width, "-m | --shadermodel <value>", "HLSL Shader Model. Only used with HLSL destination. Values: [5.0, 6.0]");
+    SDL_Log("  %-*s %s", column_width, "-p | --platform <value>", "Target platform. Only used with METALLIB destination. Values: [macOS, iOS]");
     SDL_Log("  %-*s %s", column_width, "-o | --output <value>", "Output file.");
 }
 
@@ -53,11 +64,13 @@ int main(int argc, char *argv[])
     bool destinationValid = false;
     bool stageValid = false;
     bool shaderModelValid = false; // only required for HLSL destination
+    bool platformValid = false; // only required for METALLIB destination
 
     bool spirvSource = false;
     ShaderCross_ShaderFormat destinationFormat = SHADERFORMAT_INVALID;
     SDL_ShaderCross_ShaderStage shaderStage = SDL_SHADERCROSS_SHADERSTAGE_VERTEX;
     SDL_ShaderCross_ShaderModel shaderModel;
+    ShaderCross_Platform platform;
     char *outputFilename = NULL;
     char *entrypointName = "main";
 
@@ -113,8 +126,11 @@ int main(int argc, char *argv[])
                 } else if (SDL_strcasecmp(argv[i], "HLSL") == 0) {
                     destinationFormat = SHADERFORMAT_HLSL;
                     destinationValid = true;
+                } else if (SDL_strcasecmp(argv[i], "METALLIB") == 0) {
+                    destinationFormat = SHADERFORMAT_METALLIB;
+                    destinationValid = true;
                 } else {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unrecognized destination input %s, destination must be DXBC, DXIL, MSL or SPIRV!", argv[i]);
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unrecognized destination input %s, destination must be SPIRV, DXBC, DXIL, MSL, METALLIB, or HLSL!", argv[i]);
                     print_help();
                     return 1;
                 }
@@ -162,6 +178,24 @@ int main(int argc, char *argv[])
                     shaderModelValid = true;
                 } else {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s is not a recognized HLSL Shader Model!", argv[i]);
+                    print_help();
+                    return 1;
+                }
+            } else if (SDL_strcmp(arg, "-p") == 0 || SDL_strcmp(arg, "--platform") == 0) {
+                if (i + 1 >= argc) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s requires an argument", arg);
+                    print_help();
+                    return 1;
+                }
+                i += 1;
+                if (SDL_strcasecmp(argv[i], "macOS") == 0) {
+                    platform = PLATFORM_METAL_MACOS;
+                    platformValid = true;
+                } else if (SDL_strcasecmp(argv[i], "iOS") == 0) {
+                    platform = PLATFORM_METAL_IOS;
+                    platformValid = true;
+                } else {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s is not a recognized platform!", argv[i]);
                     print_help();
                     return 1;
                 }
@@ -229,6 +263,8 @@ int main(int argc, char *argv[])
             destinationFormat = SHADERFORMAT_DXIL;
         } else if (SDL_strstr(outputFilename, ".msl")) {
             destinationFormat = SHADERFORMAT_MSL;
+        } else if (SDL_strstr(outputFilename, ".metallib")) {
+            destinationFormat = SHADERFORMAT_METALLIB;
         } else if (SDL_strstr(outputFilename, ".spv")) {
             destinationFormat = SHADERFORMAT_SPIRV;
         } else if (SDL_strstr(outputFilename, ".hlsl")) {
@@ -255,7 +291,6 @@ int main(int argc, char *argv[])
     }
 
     SDL_IOStream *outputIO = SDL_IOFromFile(outputFilename, "w");
-
     if (outputIO == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         return 1;
@@ -297,6 +332,43 @@ int main(int argc, char *argv[])
                     shaderStage);
                 SDL_IOprintf(outputIO, "%s", buffer);
                 SDL_free(buffer);
+                break;
+            }
+
+            case SHADERFORMAT_METALLIB: {
+                if (!platformValid) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "METALLIB destination requires a target platform!");
+                    print_help();
+                    return 1;
+                }
+
+                if (!check_for_metal_tools())
+                {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "xcrun not found! Is Xcode installed and activated?");
+                    return 1;
+                }
+
+                // We won't generate the metallib file directly...
+                SDL_CloseIO(outputIO);
+                outputIO = NULL;
+
+                // ...instead we'll send the MSL to a temp file and then compile that.
+                SDL_IOStream *tempFileIO = SDL_IOFromFile("tmp.metal", "w");
+                char *buffer = SDL_ShaderCross_TranspileMSLFromSPIRV(
+                    fileData,
+                    fileSize,
+                    entrypointName,
+                    shaderStage);
+                SDL_IOprintf(tempFileIO, "%s", buffer);
+                SDL_free(buffer);
+                SDL_CloseIO(tempFileIO);
+
+                int exitcode = compile_metallib(platform, outputFilename);
+                if (exitcode != 0) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Metal library creation failed with error code %d", exitcode);
+                    return 1;
+                }
+
                 break;
             }
 
@@ -373,6 +445,54 @@ int main(int argc, char *argv[])
                 break;
             }
 
+            case SHADERFORMAT_METALLIB: {
+                if (!platformValid) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "METALLIB destination requires a target platform!");
+                    print_help();
+                    return 1;
+                }
+
+                if (!check_for_metal_tools())
+                {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "xcrun not found! Is Xcode installed and activated?");
+                    return 1;
+                }
+
+                void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
+                    fileData,
+                    entrypointName,
+                    shaderStage,
+                    &bytecodeSize);
+                if (spirv == NULL) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "Failed to compile SPIR-V!");
+                    return 1;
+                }
+
+                // We won't generate the metallib file directly...
+                SDL_CloseIO(outputIO);
+                outputIO = NULL;
+
+                // ...instead we'll send the MSL to a temp file and then compile that.
+                SDL_IOStream *tempFileIO = SDL_IOFromFile("tmp.metal", "w");
+                char *buffer = SDL_ShaderCross_TranspileMSLFromSPIRV(
+                    spirv,
+                    bytecodeSize,
+                    entrypointName,
+                    shaderStage);
+                SDL_IOprintf(tempFileIO, "%s", buffer);
+                SDL_free(spirv);
+                SDL_free(buffer);
+                SDL_CloseIO(tempFileIO);
+
+                int exitcode = compile_metallib(platform, outputFilename);
+                if (exitcode != 0) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Metal library creation failed with error code %d", exitcode);
+                    return 1;
+                }
+
+                break;
+            }
+
             case SHADERFORMAT_SPIRV: {
                 Uint8 *buffer = SDL_ShaderCross_CompileSPIRVFromHLSL(
                     fileData,
@@ -425,5 +545,56 @@ int main(int argc, char *argv[])
     SDL_CloseIO(outputIO);
     SDL_free(fileData);
     SDL_ShaderCross_Quit();
+    return 0;
+}
+
+bool check_for_metal_tools(void)
+{
+    // Check for the Metal Developer Tools...
+    // FIXME: All the process calls need their Windows equivalents!
+    SDL_PropertiesID props = SDL_CreateProperties();
+    SDL_SetPointerProperty(props, SDL_PROP_PROCESS_CREATE_ARGS_POINTER, (const char*[]){ "xcrun", "--help", NULL });
+    SDL_SetNumberProperty(props, SDL_PROP_PROCESS_CREATE_STDERR_NUMBER, SDL_PROCESS_STDIO_NULL);
+    SDL_Process *process = SDL_CreateProcessWithProperties(props);
+    SDL_DestroyProperties(props);
+
+    if (process == NULL) {
+        return false;
+    }
+    SDL_DestroyProcess(process);
+    return true;
+}
+
+int compile_metallib(ShaderCross_Platform platform, const char *outputFilename)
+{
+    const char *sdkString;
+    const char *stdString;
+    const char *minversion;
+    if (platform == PLATFORM_METAL_MACOS) {
+        sdkString = "macosx";
+        stdString = "-std=macos-metal2.0";
+        minversion = "-mmacosx-version-min=10.13";
+    } else {
+        sdkString = "iphoneos";
+        stdString = "-std=ios-metal2.0";
+        minversion = "-miphoneos-version-min=13.0";
+    }
+
+    int exitcode;
+    SDL_Process *process = SDL_CreateProcess((const char*[]){ "xcrun", "-sdk", sdkString, "metal", stdString, minversion, "-Wall", "-O3", "-c", "tmp.metal", "-o", "tmp.ir", NULL }, true);
+    SDL_WaitProcess(process, true, &exitcode);
+    SDL_RemovePath("tmp.metal");
+    if (exitcode != 0) {
+        return exitcode;
+    }
+    SDL_DestroyProcess(process);
+
+    process = SDL_CreateProcess((const char*[]){ "xcrun", "-sdk", sdkString, "metallib", "tmp.ir", "-o", outputFilename, NULL }, true);
+    SDL_WaitProcess(process, true, &exitcode);
+    SDL_RemovePath("tmp.ir");
+    if (exitcode != 0) {
+        return exitcode;
+    }
+    SDL_DestroyProcess(process);
     return 0;
 }


### PR DESCRIPTION
Resolves https://github.com/libsdl-org/SDL_gpu_shadercross/issues/39

In addition to the new `METALLIB` output format, this also adds an optional `--platform` argument to specify whether you're targeting macOS or iOS. I'm not including Simulator support because the iOS simulator is actually below our min specs at this point. tvOS and iOS appear to share the same Metal bytecode format so I don't think we need a separate platform for tvOS.

Note again that this is exclusively for CLI -- runtime compilation of MSL can be handled by the Metal API with no special handling.

Remaining to-do:
- [ ] Windows support
- [ ] Linux support (somehow?)
- [ ] Test generated binaries