### PR TITLE
add SDL3 close code include

### DIFF
--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -283,5 +283,6 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
 #ifdef __cplusplus
 }
 #endif
+#include <SDL3/SDL_close_code.h>
 
 #endif /* SDL_GPU_SHADERCROSS_H */


### PR DESCRIPTION
Fixes the nested inclusion error

```
error: Nested inclusion of SDL_begin_code.h
```

when including SDL library headers after this one e.g.

```
#define SDL_MAIN_USE_CALLBACKS 1
#include <SDL3/SDL.h>
#include <SDL3/SDL_main.h>
#include <SDL3_gpu_shadercross/SDL_gpu_shadercross.h>
#include <SDL3_image/SDL_image.h>
```