### PR TITLE
Link SPIRV-Cross instead of using SDL_LoadObject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,11 @@ if(SDLGPUSHADERCROSS_STATIC)
 	)
 endif()
 
+find_package(spirv_cross_c_shared REQUIRED)
 foreach(target IN LISTS SDL3_gpu_shadercross_targets)
 	sdl_add_warning_options(${target} WARNING_AS_ERROR ${SDLGPUSHADERCROSS_WERROR})
 	target_compile_features(${target} PRIVATE c_std_99)
+	target_link_libraries(${target} PRIVATE spirv-cross-c-shared)
 endforeach()
 
 if(NOT TARGET SDL3_gpu_shadercross::SDL3_gpu_shadercross)


### PR DESCRIPTION
We can probably stop vendoring spirv_cross_c.h and spirv.h now that we're linking, right?

Addresses #44 