### PR TITLE
Don't find SDL3::Headers and SDL3::SDL3{-shared} if the targets exists already

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/PrivateSdlFunctions.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcpu.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 
-find_package(SDL3 REQUIRED COMPONENTS SDL3-shared)
+if(NOT TARGET SDL3::Headers OR NOT TARGET SDL3::SDL3-shared)
+    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS SDL3::Headers SDL3::SDL3-shared)
+endif()
 
 if(BUILD_SHARED_LIBS)
 	set(SDLGPUSHADERCROSS_SHARED_DEFAULT ON)
@@ -104,7 +106,9 @@ endif()
 
 if(SDLGPUSHADERCROSS_STATIC)
 	list(APPEND SDL3_gpu_shadercross_targets SDL3_gpu_shadercross-static)
-	find_package(SDL3 REQUIRED COMPONENTS Headers)
+	if(NOT TARGET SDL3::Headers OR NOT TARGET SDL3::SDL3)
+		find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS SDL3::Headers SDL3::SDL3)
+	endif()
 
 	add_library(SDL3_gpu_shadercross-static STATIC ${SOURCE_FILES})
 	add_library(SDL3_gpu_shadercross::SDL3_gpu_shadercross-static ALIAS SDL3_gpu_shadercross-static)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlcpu.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/sdlplatform.cmake")
 
 if(NOT TARGET SDL3::Headers OR NOT TARGET SDL3::SDL3-shared)
-    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS SDL3::Headers SDL3::SDL3-shared)
+    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS Headers SDL3-shared)
 endif()
 
 if(BUILD_SHARED_LIBS)
@@ -107,7 +107,7 @@ endif()
 if(SDLGPUSHADERCROSS_STATIC)
 	list(APPEND SDL3_gpu_shadercross_targets SDL3_gpu_shadercross-static)
 	if(NOT TARGET SDL3::Headers OR NOT TARGET SDL3::SDL3)
-		find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS SDL3::Headers SDL3::SDL3)
+		find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS Headers)
 	endif()
 
 	add_library(SDL3_gpu_shadercross-static STATIC ${SOURCE_FILES})


### PR DESCRIPTION
When vendoring `SDL`, `SPIRV-Cross` and `SDL_gpu_shadercross` SDL3 can't be found with the following snippet from `CMakeLists.txt`. This change doesn't look for SDL3 if the targets already exist. Similar approach to SDL_image.

```
add_subdirectory(deps/SDL)
add_subdirectory(deps/SPIRV-Cross)
add_subdirectory(deps/SDL_gpu_shadercross)
```
