### PR TITLE
Add support for HLSL include dirs

### DIFF
--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -144,7 +144,6 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_TranspileHLSLFromSPIRV(
  * \param bytecode the SPIRV bytecode.
  * \param bytecodeSize the length of the SPIRV bytecode.
  * \param entrypoint the entry point function name for the shader in UTF-8.
- * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  */
@@ -152,7 +151,6 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -164,7 +162,6 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromSPIRV(
  * \param bytecode the SPIRV bytecode.
  * \param bytecodeSize the length of the SPIRV bytecode.
  * \param entrypoint the entry point function name for the shader in UTF-8.
- * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  */
@@ -172,7 +169,6 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 

--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -144,6 +144,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_TranspileHLSLFromSPIRV(
  * \param bytecode the SPIRV bytecode.
  * \param bytecodeSize the length of the SPIRV bytecode.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  */
@@ -151,6 +152,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -162,6 +164,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromSPIRV(
  * \param bytecode the SPIRV bytecode.
  * \param bytecodeSize the length of the SPIRV bytecode.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  */
@@ -169,6 +172,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -229,6 +233,7 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_ShaderCross_GetHLSLShaderFor
  *
  * \param hlslSource the HLSL source code for the shader.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  * \returns an SDL_malloc'd buffer containing DXBC bytecode.
@@ -238,6 +243,7 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_ShaderCross_GetHLSLShaderFor
 extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -248,6 +254,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
  *
  * \param hlslSource the HLSL source code for the shader.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  * \returns an SDL_malloc'd buffer containing DXIL bytecode.
@@ -257,6 +264,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
 extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -267,6 +275,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
  *
  * \param hlslSource the HLSL source code for the shader.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param shaderStage the shader stage to compile the shader with.
  * \param size filled in with the bytecode buffer size.
  * \returns an SDL_malloc'd buffer containing SPIRV bytecode.
@@ -276,6 +285,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
 extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileSPIRVFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size);
 
@@ -285,6 +295,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileSPIRVFromHLSL(
  * \param device the SDL GPU device.
  * \param hlslSource the HLSL source code for the shader.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param graphicsShaderStage the shader stage to compile the shader with.
  * \param resourceInfo a pointer to an SDL_ShaderCross_ShaderResourceInfo.
  * \returns a compiled SDL_GPUShader
@@ -295,6 +306,7 @@ extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShade
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_GPUShaderStage graphicsShaderStage,
     const SDL_ShaderCross_ShaderResourceInfo *resourceInfo);
 
@@ -304,6 +316,7 @@ extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShade
  * \param device the SDL GPU device.
  * \param hlslSource the HLSL source code for the shader.
  * \param entrypoint the entry point function name for the shader in UTF-8.
+ * \param includeDir the include directory for shader code. Optional, can be NULL.
  * \param resourceInfo a pointer to an SDL_ShaderCross_ComputeResourceInfo.
  * \returns a compiled SDL_GPUComputePipeline
  *
@@ -313,6 +326,7 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     const SDL_ShaderCross_ComputeResourceInfo *resourceInfo);
 
 #endif /* SDL_GPU_SHADERCROSS_HLSL */

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -256,6 +256,63 @@ struct IDxcCompiler3
     const IDxcCompiler3Vtbl *lpVtbl;
 };
 
+// We need all this DxcUtils garbage for DXC include dir support. Thanks Microsoft!
+typedef struct IMalloc IMalloc;
+typedef struct IStream IStream;
+typedef struct DxcDefine DxcDefine;
+typedef struct IDxcCompilerArgs IDxcCompilerArgs;
+
+static struct
+{
+    Uint32 Data1;
+    Uint16 Data2;
+    Uint16 Data3;
+    Uint8 Data4[8];
+} CLSID_DxcUtils = {
+    .Data1 = 0x6245d6af,
+    .Data2 = 0x66e0,
+    .Data3 = 0x48fd,
+    .Data4 = {0x80, 0xb4, 0x4d, 0x27, 0x17, 0x96, 0x74, 0x8c}};
+static Uint8 IID_IDxcUtils[] = {
+    0xcb, 0xc4, 0x05, 0x46,
+    0x19, 0x20,
+    0x2a, 0x49,
+    0xad,
+    0xa4,
+    0x65,
+    0xf2,
+    0x0b,
+    0xb7,
+    0xd6,
+    0x7f
+};
+typedef struct IDxcUtilsVtbl
+{
+    HRESULT (__stdcall *QueryInterface)(void *pSelf, REFIID riid, void **ppvObject);
+    ULONG (__stdcall *AddRef)(void *pSelf);
+    ULONG (__stdcall *Release)(void *pSelf);
+
+    HRESULT (__stdcall *CreateBlobFromBlob)(void *pSelf, IDxcBlob *pBlob, UINT offset, UINT length, IDxcBlob **ppResult);
+    HRESULT (__stdcall *CreateBlobFromPinned)(void *pSelf, LPCVOID pData, UINT size, UINT codePage, IDxcBlobEncoding **pBlobEncoding);
+    HRESULT (__stdcall *MoveToBlob)(void *pSelf, LPCVOID pData, IMalloc *pIMalloc, UINT size, UINT codePage, IDxcBlobEncoding **pBlobEncoding);
+    HRESULT (__stdcall *CreateBlob)(void *pSelf, LPCVOID pData, UINT size, UINT codePage, IDxcBlobEncoding **pBlobEncoding);
+    HRESULT (__stdcall *LoadFile)(void *pSelf, LPCWSTR pFileName, UINT *pCodePage, IDxcBlobEncoding **pBlobEncoding);
+    HRESULT (__stdcall *CreateReadOnlyStreamFromBlob)(void *pSelf, IDxcBlob *pBlob, IStream **ppStream);
+    HRESULT (__stdcall *CreateDefaultIncludeHandler)(void *pSelf, IDxcIncludeHandler **ppResult);
+    HRESULT (__stdcall *GetBlobAsUtf8)(void *pSelf, IDxcBlob *pBlob, IDxcBlobUtf8 **pBlobEncoding);
+    HRESULT (__stdcall *GetBlobAsWide)(void *pSelf, IDxcBlob *pBlob, IDxcBlobWide **pBlobEncoding);
+    HRESULT (__stdcall *GetDxilContainerPart)(void *pSelf, const DxcBuffer *pShader, UINT DxcPart, void **ppPartData, UINT *pPartSizeInBytes);
+    HRESULT (__stdcall *CreateReflection)(void *pSelf, const DxcBuffer *pData, REFIID iid, void **ppvReflection);
+    HRESULT (__stdcall *BuildArguments)(void *pSelf, LPCWSTR pSourceName, LPCWSTR pEntryPoint, LPCWSTR pTargetProfile, LPCWSTR *pArguments, UINT argCount, const DxcDefine *pDefines, UINT defineCount, IDxcCompilerArgs **ppArgs);
+    HRESULT (__stdcall *GetPDBContents)(void *pSelf, IDxcBlob *pPDBBlob, IDxcBlob **ppHash, IDxcBlob **ppContainer);
+} IDxcUtilsVtbl;
+
+typedef struct IDxcUtils IDxcUtils;
+struct IDxcUtils
+{
+    const IDxcUtilsVtbl *lpVtbl;
+};
+
 /* *INDENT-ON* */ // clang-format on
 
 /* DXCompiler */
@@ -273,6 +330,7 @@ HRESULT DxcCreateInstance(REFCLSID rclsid, REFIID riid, LPVOID *ppv);
 static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     bool spirv,
     size_t *size) // filled in with number of bytes of returned buffer
@@ -283,9 +341,14 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     IDxcBlobUtf8 *errors;
     size_t entryPointLength = SDL_utf8strlen(entrypoint) + 1;
     wchar_t *entryPointUtf16 = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", entrypoint, entryPointLength);
+    size_t includeDirLength = 0;
+    wchar_t *includeDirUtf16 = NULL;
+
     LPCWSTR args[] = {
         (LPCWSTR)L"-E",
         (LPCWSTR)entryPointUtf16,
+        NULL,
+        NULL,
         NULL,
         NULL,
         NULL,
@@ -294,8 +357,18 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     Uint32 argCount = 2;
     HRESULT ret;
 
+    if (includeDir != NULL) {
+        includeDirLength = SDL_utf8strlen(includeDir) + 1;
+        includeDirUtf16 = (wchar_t *)SDL_iconv_string("WCHAR_T", "UTF-8", includeDir, includeDirLength);
+        args[2] = (LPCWSTR)L"-I";
+        args[3] = includeDirUtf16;
+        argCount += 2;
+    }
+
     /* Non-static DxcInstance, since the functions we call on it are not thread-safe */
     IDxcCompiler3 *dxcInstance = NULL;
+    IDxcUtils *utils = NULL;
+    IDxcIncludeHandler *includeHandler = NULL;
 
     #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     if (SDL_DxcCreateInstance == NULL) {
@@ -306,16 +379,34 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         &CLSID_DxcCompiler,
         IID_IDxcCompiler3,
         (void **)&dxcInstance);
+
+    SDL_DxcCreateInstance(
+        &CLSID_DxcUtils,
+        &IID_IDxcUtils,
+        (void **)(&utils));
     #else
     DxcCreateInstance(
         &CLSID_DxcCompiler,
         IID_IDxcCompiler3,
         (void **)&dxcInstance);
+
+    DxcCreateInstance(
+        &CLSID_DxcUtils,
+        &IID_IDxcUtils,
+        (void **)(&utils));
     #endif
 
     if (dxcInstance == NULL) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "Could not create DXC instance!");
         return NULL;
     }
+
+    if (utils == NULL) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "Could not create DXC utils instance!");
+        return NULL;
+    }
+
+    utils->lpVtbl->CreateDefaultIncludeHandler(utils, &includeHandler);
 
     source.Ptr = hlslSource;
     source.Size = SDL_strlen(hlslSource) + 1;
@@ -345,22 +436,27 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         &source,
         args,
         argCount,
-        NULL,
+        includeHandler,
         IID_IDxcResult,
         (void **)&dxcResult);
 
     SDL_free(entryPointUtf16);
+    if (includeDir != NULL) {
+        SDL_free(includeDirUtf16);
+    }
 
     if (ret < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU,
                      "IDxcShaderCompiler3::Compile failed: %X",
                      ret);
         dxcInstance->lpVtbl->Release(dxcInstance);
+        utils->lpVtbl->Release(utils);
         return NULL;
     } else if (dxcResult == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU,
                      "HLSL compilation failed with no IDxcResult");
         dxcInstance->lpVtbl->Release(dxcInstance);
+        utils->lpVtbl->Release(utils);
         return NULL;
     }
 
@@ -375,6 +471,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
                      (char *)errors->lpVtbl->GetBufferPointer(errors));
         dxcResult->lpVtbl->Release(dxcResult);
         dxcInstance->lpVtbl->Release(dxcInstance);
+        utils->lpVtbl->Release(utils);
         return NULL;
     }
 
@@ -387,6 +484,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "IDxcBlob fetch failed");
         dxcResult->lpVtbl->Release(dxcResult);
         dxcInstance->lpVtbl->Release(dxcInstance);
+        utils->lpVtbl->Release(utils);
         return NULL;
     }
 
@@ -394,8 +492,10 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
     void *buffer = SDL_malloc(*size);
     SDL_memcpy(buffer, blob->lpVtbl->GetBufferPointer(blob), *size);
 
+    blob->lpVtbl->Release(blob);
     dxcResult->lpVtbl->Release(dxcResult);
     dxcInstance->lpVtbl->Release(dxcInstance);
+    utils->lpVtbl->Release(utils);
 
     return buffer;
 }
@@ -403,6 +503,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
 void *SDL_ShaderCross_CompileDXILFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
@@ -411,6 +512,7 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
     void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
         hlslSource,
         entrypoint,
+        includeDir,
         shaderStage,
         &spirvSize);
 
@@ -433,6 +535,7 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
     return SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         translatedSource,
         entrypoint,
+        includeDir,
         shaderStage,
         false,
         size);
@@ -441,12 +544,14 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
 void *SDL_ShaderCross_CompileSPIRVFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
     return SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         hlslSource,
         entrypoint,
+        includeDir,
         shaderStage,
         true,
         size);
@@ -456,6 +561,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromDXC(
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     const void *resourceInfo,
     bool spirv)
@@ -469,6 +575,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromDXC(
         bytecode = SDL_ShaderCross_CompileDXILFromHLSL(
             hlslSource,
             entrypoint,
+            includeDir,
             shaderStage,
             &bytecodeSize);
     } else {
@@ -476,6 +583,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromDXC(
         bytecode = SDL_ShaderCross_INTERNAL_CompileUsingDXC(
             hlslSource,
             entrypoint,
+            includeDir,
             shaderStage,
             spirv,
             &bytecodeSize);
@@ -635,6 +743,7 @@ static ID3DBlob *SDL_ShaderCross_INTERNAL_CompileDXBC(
 void *SDL_ShaderCross_CompileDXBCFromHLSL(
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size) // filled in with number of bytes of returned buffer
 {
@@ -643,6 +752,7 @@ void *SDL_ShaderCross_CompileDXBCFromHLSL(
     void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
         hlslSource,
         entrypoint,
+        includeDir,
         shaderStage,
         &spirv_size);
 
@@ -696,6 +806,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     const void *resourceInfo)
 {
@@ -705,6 +816,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
     void *bytecode = SDL_ShaderCross_CompileDXBCFromHLSL(
         hlslSource,
         entrypoint,
+        includeDir,
         shaderStage,
         &bytecodeSize);
 
@@ -756,6 +868,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     const void *resourceInfo)
 {
@@ -764,6 +877,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
         return SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
             device,
             hlslSource,
+            includeDir,
             entrypoint,
             shaderStage,
             resourceInfo);
@@ -773,6 +887,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
             device,
             hlslSource,
             entrypoint,
+            includeDir,
             shaderStage,
             resourceInfo,
             false);
@@ -782,6 +897,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
             device,
             hlslSource,
             entrypoint,
+            includeDir,
             shaderStage,
             resourceInfo,
             true);
@@ -791,6 +907,7 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
         void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
             hlslSource,
             entrypoint,
+            includeDir,
             shaderStage,
             &bytecodeSize);
         if (spirv == NULL) {
@@ -826,6 +943,7 @@ SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromHLSL(
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     SDL_GPUShaderStage graphicsShaderStage,
     const SDL_ShaderCross_ShaderResourceInfo *resourceInfo)
 {
@@ -833,6 +951,7 @@ SDL_GPUShader *SDL_ShaderCross_CompileGraphicsShaderFromHLSL(
         device,
         hlslSource,
         entrypoint,
+        includeDir,
         (SDL_ShaderCross_ShaderStage)graphicsShaderStage,
         (const void *)resourceInfo);
 }
@@ -841,12 +960,14 @@ SDL_GPUComputePipeline *SDL_ShaderCross_CompileComputePipelineFromHLSL(
     SDL_GPUDevice *device,
     const char *hlslSource,
     const char *entrypoint,
+    const char *includeDir,
     const SDL_ShaderCross_ComputeResourceInfo *resourceInfo)
 {
     return (SDL_GPUComputePipeline *)SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
         device,
         hlslSource,
         entrypoint,
+        includeDir,
         SDL_SHADERCROSS_SHADERSTAGE_COMPUTE,
         (const void *)resourceInfo);
 }
@@ -1444,12 +1565,14 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
             createInfo.code = SDL_ShaderCross_CompileDXBCFromHLSL(
                 transpileContext->translated_source,
                 transpileContext->cleansed_entrypoint,
+                NULL,
                 shaderStage,
                 &createInfo.code_size);
         } else if (targetFormat == SDL_GPU_SHADERFORMAT_DXIL) {
             createInfo.code = SDL_ShaderCross_CompileDXILFromHLSL(
                 transpileContext->translated_source,
                 transpileContext->cleansed_entrypoint,
+                NULL,
                 shaderStage,
                 &createInfo.code_size);
         } else { // MSL
@@ -1474,12 +1597,14 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
             createInfo.code = SDL_ShaderCross_CompileDXBCFromHLSL(
                 transpileContext->translated_source,
                 transpileContext->cleansed_entrypoint,
+                NULL,
                 shaderStage,
                 &createInfo.code_size);
         } else if (targetFormat == SDL_GPU_SHADERFORMAT_DXIL) {
             createInfo.code = SDL_ShaderCross_CompileDXILFromHLSL(
                 transpileContext->translated_source,
                 transpileContext->cleansed_entrypoint,
+                NULL,
                 shaderStage,
                 &createInfo.code_size);
         } else { // MSL
@@ -1556,6 +1681,7 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
@@ -1570,6 +1696,7 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     void *result = SDL_ShaderCross_CompileDXBCFromHLSL(
         context->translated_source,
         context->cleansed_entrypoint,
+        includeDir,
         shaderStage,
         size);
 
@@ -1581,6 +1708,7 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
+    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
@@ -1595,6 +1723,7 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     void *result = SDL_ShaderCross_CompileDXILFromHLSL(
         context->translated_source,
         context->cleansed_entrypoint,
+        includeDir,
         shaderStage,
         size);
 

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -900,8 +900,8 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
         return SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
             device,
             hlslSource,
-            includeDir,
             entrypoint,
+            includeDir,
             shaderStage,
             resourceInfo);
     }

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -1681,7 +1681,6 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
@@ -1696,7 +1695,7 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
     void *result = SDL_ShaderCross_CompileDXBCFromHLSL(
         context->translated_source,
         context->cleansed_entrypoint,
-        includeDir,
+        NULL,
         shaderStage,
         size);
 
@@ -1708,7 +1707,6 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    const char *includeDir,
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size)
 {
@@ -1723,7 +1721,7 @@ void *SDL_ShaderCross_CompileDXILFromSPIRV(
     void *result = SDL_ShaderCross_CompileDXILFromHLSL(
         context->translated_source,
         context->cleansed_entrypoint,
-        includeDir,
+        NULL,
         shaderStage,
         size);
 

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -441,7 +441,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileUsingDXC(
         (void **)&dxcResult);
 
     SDL_free(entryPointUtf16);
-    if (includeDir != NULL) {
+    if (includeDirUtf16 != NULL) {
         SDL_free(includeDirUtf16);
     }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -43,7 +43,7 @@ void print_help(void)
     SDL_Log("  %-*s %s", column_width, "-t | --stage <value>", "Shader stage. May be inferred from the filename. Values: [vertex, fragment, compute]");
     SDL_Log("  %-*s %s", column_width, "-e | --entrypoint <value>", "Entrypoint function name. Default: \"main\".");
     SDL_Log("  %-*s %s", column_width, "-m | --shadermodel <value>", "HLSL Shader Model. Only used with HLSL destination. Values: [5.0, 6.0]");
-    SDL_Log("  %-*s %s", column_width, "-i | --include <value>", "HLSL include directory. Only used with HLSL source. Optional.");
+    SDL_Log("  %-*s %s", column_width, "-I | --include <value>", "HLSL include directory. Only used with HLSL source. Optional.");
     SDL_Log("  %-*s %s", column_width, "-o | --output <value>", "Output file.");
 }
 
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
                     print_help();
                     return 1;
                 }
-            } else if (SDL_strcmp(arg, "-i") == 0 || SDL_strcmp(arg, "--include") == 0) {
+            } else if (SDL_strcmp(arg, "-I") == 0 || SDL_strcmp(arg, "--include") == 0) {
                 if (includeDir) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "'%s' can only be used once", arg);
                     print_help();

--- a/src/cli.c
+++ b/src/cli.c
@@ -43,6 +43,7 @@ void print_help(void)
     SDL_Log("  %-*s %s", column_width, "-t | --stage <value>", "Shader stage. May be inferred from the filename. Values: [vertex, fragment, compute]");
     SDL_Log("  %-*s %s", column_width, "-e | --entrypoint <value>", "Entrypoint function name. Default: \"main\".");
     SDL_Log("  %-*s %s", column_width, "-m | --shadermodel <value>", "HLSL Shader Model. Only used with HLSL destination. Values: [5.0, 6.0]");
+    SDL_Log("  %-*s %s", column_width, "-i | --include <value>", "HLSL include directory. Only used with HLSL source. Optional.");
     SDL_Log("  %-*s %s", column_width, "-o | --output <value>", "Output file.");
 }
 
@@ -60,6 +61,7 @@ int main(int argc, char *argv[])
     SDL_ShaderCross_ShaderModel shaderModel = SDL_SHADERCROSS_SHADERMODEL_INVALID;
     char *outputFilename = NULL;
     char *entrypointName = "main";
+    char *includeDir = NULL;
 
     char *filename = NULL;
     size_t fileSize = 0;
@@ -165,6 +167,14 @@ int main(int argc, char *argv[])
                     print_help();
                     return 1;
                 }
+            } else if (SDL_strcmp(arg, "-i") == 0 || SDL_strcmp(arg, "--include") == 0) {
+                if (i + 1 >= argc) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s requires an argument", arg);
+                    print_help();
+                    return 1;
+                }
+                i += 1;
+                includeDir = argv[i];
             } else if (SDL_strcmp(arg, "-o") == 0 || SDL_strcmp(arg, "--output") == 0) {
                 if (i + 1 >= argc) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s requires an argument", arg);
@@ -270,6 +280,7 @@ int main(int argc, char *argv[])
                     fileData,
                     fileSize,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -282,6 +293,7 @@ int main(int argc, char *argv[])
                     fileData,
                     fileSize,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -339,6 +351,7 @@ int main(int argc, char *argv[])
                 Uint8 *buffer = SDL_ShaderCross_CompileDXBCFromHLSL(
                     fileData,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -350,6 +363,7 @@ int main(int argc, char *argv[])
                 Uint8 *buffer = SDL_ShaderCross_CompileDXILFromHLSL(
                     fileData,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -361,6 +375,7 @@ int main(int argc, char *argv[])
                 void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
                     fileData,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 if (spirv == NULL) {
@@ -382,6 +397,7 @@ int main(int argc, char *argv[])
                 Uint8 *buffer = SDL_ShaderCross_CompileSPIRVFromHLSL(
                     fileData,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -399,6 +415,7 @@ int main(int argc, char *argv[])
                 void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
                     fileData,
                     entrypointName,
+                    includeDir,
                     shaderStage,
                     &bytecodeSize);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -280,7 +280,6 @@ int main(int argc, char *argv[])
                     fileData,
                     fileSize,
                     entrypointName,
-                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
@@ -293,7 +292,6 @@ int main(int argc, char *argv[])
                     fileData,
                     fileSize,
                     entrypointName,
-                    includeDir,
                     shaderStage,
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);

--- a/src/cli.c
+++ b/src/cli.c
@@ -168,6 +168,11 @@ int main(int argc, char *argv[])
                     return 1;
                 }
             } else if (SDL_strcmp(arg, "-i") == 0 || SDL_strcmp(arg, "--include") == 0) {
+                if (includeDir) {
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "'%s' can only be used once", arg);
+                    print_help();
+                    return 1;
+                }
                 if (i + 1 >= argc) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s requires an argument", arg);
                     print_help();


### PR DESCRIPTION
All HLSL functions now take an optional `includeDir` parameter. From CLI you can do `-I <path>` or `--include <path>` to specify the include dir. 

Resolves #53 