### PR TITLE
Optional DXC usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ else()
 endif()
 
 # Options
+option(SDLGPUSHADERCROSS_DXC "Enable HLSL compilation via DXC" ON)
 option(SDLGPUSHADERCROSS_SHARED "Build shared SDL_gpu_shadercross library" ${SDLGPUSHADERCROSS_SHARED_DEFAULT})
 option(SDLGPUSHADERCROSS_STATIC "Build static SDL_gpu_shadercross library" ${SDLGPUSHADERCROSS_STATIC_DEFAULT})
 option(SDLGPUSHADERCROSS_SPIRVCROSS_SHARED "Link to shared library variants of dependencies" ON)
@@ -208,6 +209,10 @@ endif()
 foreach(target IN LISTS SDL3_gpu_shadercross_targets)
 	sdl_add_warning_options(${target} WARNING_AS_ERROR ${SDLGPUSHADERCROSS_WERROR})
 	target_compile_features(${target} PRIVATE c_std_99)
+
+	if(SDLGPUSHADERCROSS_DXC)
+		add_compile_definitions(SDL_GPU_SHADERCROSS_DXC)
+	endif()
 
 	if(SDLGPUSHADERCROSS_SPIRVCROSS_SHARED)
 		target_link_libraries(${target} PRIVATE spirv-cross-c-shared)

--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -223,7 +223,7 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
 extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_ShaderCross_GetHLSLShaderFormats(void);
 
 /**
- * Compile to DXBC bytecode from HLSL Shader Model 6.0 code via a SPIRV-Cross round trip.
+ * Compile to DXBC bytecode from HLSL code via a SPIRV-Cross round trip.
  *
  * You must SDL_free the returned buffer once you are done with it.
  *
@@ -244,7 +244,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXBCFromHLSL(
     size_t *size);
 
 /**
- * Compile to DXIL bytecode from HLSL Shader Model 6.0 code via a SPIRV-Cross round trip.
+ * Compile to DXIL bytecode from HLSL code via a SPIRV-Cross round trip.
  *
  * You must SDL_free the returned buffer once you are done with it.
  *
@@ -265,7 +265,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileDXILFromHLSL(
     size_t *size);
 
 /**
- * Compile to SPIRV bytecode from HLSL Shader Model 6.0 code.
+ * Compile to SPIRV bytecode from HLSL code.
  *
  * You must SDL_free the returned buffer once you are done with it.
  *
@@ -286,7 +286,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_CompileSPIRVFromHLSL(
     size_t *size);
 
 /**
- * Compile an SDL GPU shader from HLSL Shader Model 6.0 code.
+ * Compile an SDL GPU shader from HLSL code.
  *
  * \param device the SDL GPU device.
  * \param hlslSource the HLSL source code for the shader.
@@ -307,7 +307,7 @@ extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShade
     const SDL_ShaderCross_ShaderResourceInfo *resourceInfo);
 
 /**
- * Compile an SDL GPU compute pipeline from HLSL Shader Model 6.0 code.
+ * Compile an SDL GPU compute pipeline from code.
  *
  * \param device the SDL GPU device.
  * \param hlslSource the HLSL source code for the shader.

--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -38,14 +38,6 @@ extern "C" {
 #define SDL_GPU_SHADERCROSS_MINOR_VERSION 0
 #define SDL_GPU_SHADERCROSS_MICRO_VERSION 0
 
-#ifndef SDL_GPU_SHADERCROSS_SPIRVCROSS
-#define SDL_GPU_SHADERCROSS_SPIRVCROSS 1
-#endif /* SDL_GPU_SHADERCROSS_SPIRVCROSS */
-
-#ifndef SDL_GPU_SHADERCROSS_HLSL
-#define SDL_GPU_SHADERCROSS_HLSL 1
-#endif /* SDL_GPU_SHADERCROSS_HLSL */
-
 typedef enum SDL_ShaderCross_ShaderStage
 {
    SDL_SHADERCROSS_SHADERSTAGE_VERTEX,
@@ -92,7 +84,6 @@ extern SDL_DECLSPEC bool SDLCALL SDL_ShaderCross_Init(void);
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ShaderCross_Quit(void);
 
-#if SDL_GPU_SHADERCROSS_SPIRVCROSS
 /**
  * Get the supported shader formats that SPIRV cross-compilation can output
  *
@@ -212,9 +203,6 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
     const char *entrypoint,
     const SDL_ShaderCross_ComputeResourceInfo *resourceInfo);
 
-#endif /* SDL_GPU_SHADERCROSS_SPIRVCROSS */
-
-#if SDL_GPU_SHADERCROSS_HLSL
 /**
  * Get the supported shader formats that HLSL cross-compilation can output
  *
@@ -324,8 +312,6 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComp
     const char *entrypoint,
     const char *includeDir,
     const SDL_ShaderCross_ComputeResourceInfo *resourceInfo);
-
-#endif /* SDL_GPU_SHADERCROSS_HLSL */
 
 #ifdef __cplusplus
 }

--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -56,7 +56,7 @@ typedef enum SDL_ShaderCross_ShaderStage
 typedef enum SDL_ShaderCross_ShaderModel
 {
     SDL_SHADERCROSS_SHADERMODEL_INVALID,
-    SDL_SHADERCROSS_SHADERMODEL_5_0,
+    SDL_SHADERCROSS_SHADERMODEL_5_1,
     SDL_SHADERCROSS_SHADERMODEL_6_0
 } SDL_ShaderCross_ShaderModel;
 

--- a/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
+++ b/include/SDL3_gpu_shadercross/SDL_gpu_shadercross.h
@@ -45,13 +45,6 @@ typedef enum SDL_ShaderCross_ShaderStage
    SDL_SHADERCROSS_SHADERSTAGE_COMPUTE
 } SDL_ShaderCross_ShaderStage;
 
-typedef enum SDL_ShaderCross_ShaderModel
-{
-    SDL_SHADERCROSS_SHADERMODEL_INVALID,
-    SDL_SHADERCROSS_SHADERMODEL_5_1,
-    SDL_SHADERCROSS_SHADERMODEL_6_0
-} SDL_ShaderCross_ShaderModel;
-
 typedef struct SDL_ShaderCross_ShaderResourceInfo {
     Uint32 num_samplers;         /**< The number of samplers defined in the shader. */
     Uint32 num_storage_textures; /**< The number of storage textures defined in the shader. */
@@ -124,8 +117,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ShaderCross_TranspileHLSLFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    SDL_ShaderCross_ShaderStage shaderStage,
-    SDL_ShaderCross_ShaderModel shaderModel);
+    SDL_ShaderCross_ShaderStage shaderStage);
 
 /**
  * Compile DXBC bytecode from SPIRV code.

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -793,7 +793,7 @@ void *SDL_ShaderCross_CompileDXBCFromHLSL(
         spirv_size,
         entrypoint,
         shaderStage,
-        SDL_SHADERCROSS_SHADERMODEL_5_0
+        SDL_SHADERCROSS_SHADERMODEL_5_1
     );
     SDL_free(spirv);
 
@@ -803,11 +803,11 @@ void *SDL_ShaderCross_CompileDXBCFromHLSL(
 
     const char *shaderProfile;
     if (shaderStage == SDL_SHADERCROSS_SHADERSTAGE_VERTEX) {
-        shaderProfile = "vs_5_0";
+        shaderProfile = "vs_5_1";
     } else if (shaderStage == SDL_SHADERCROSS_SHADERSTAGE_FRAGMENT) {
-        shaderProfile = "ps_5_0";
+        shaderProfile = "ps_5_1";
     } else { // compute
-        shaderProfile = "cs_5_0";
+        shaderProfile = "cs_5_1";
     }
 
     ID3DBlob *blob = SDL_ShaderCross_INTERNAL_CompileDXBC(
@@ -1552,7 +1552,7 @@ static void *SDL_ShaderCross_INTERNAL_CompileFromSPIRV(
 
     if (targetFormat == SDL_GPU_SHADERFORMAT_DXBC) {
         backend = SPVC_BACKEND_HLSL;
-        shadermodel = 50;
+        shadermodel = 51;
     } else if (targetFormat == SDL_GPU_SHADERFORMAT_DXIL) {
         backend = SPVC_BACKEND_HLSL;
         shadermodel = 60;
@@ -1679,8 +1679,8 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
 {
     unsigned int spirv_cross_shader_model = 0;
 
-    if (shaderModel == SDL_SHADERCROSS_SHADERMODEL_5_0) {
-        spirv_cross_shader_model = 50;
+    if (shaderModel == SDL_SHADERCROSS_SHADERMODEL_5_1) {
+        spirv_cross_shader_model = 51;
     } else if (shaderModel == SDL_SHADERCROSS_SHADERMODEL_6_0) {
         spirv_cross_shader_model = 60;
     } else {
@@ -1714,7 +1714,7 @@ void *SDL_ShaderCross_CompileDXBCFromSPIRV(
 {
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
-        50,
+        51,
         shaderStage,
         bytecode,
         bytecodeSize,

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -775,7 +775,7 @@ void *SDL_ShaderCross_CompileDXBCFromHLSL(
     SDL_ShaderCross_ShaderStage shaderStage,
     size_t *size) // filled in with number of bytes of returned buffer
 {
-    // Need to roundtrip to SM 5.0
+    // Need to roundtrip to SM 5.1
     size_t spirv_size;
     void *spirv = SDL_ShaderCross_CompileSPIRVFromHLSL(
         hlslSource,
@@ -901,15 +901,6 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
     const void *resourceInfo)
 {
     SDL_GPUShaderFormat format = SDL_GetGPUShaderFormats(device);
-    if (format & SDL_GPU_SHADERFORMAT_DXBC) {
-        return SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
-            device,
-            hlslSource,
-            entrypoint,
-            includeDir,
-            shaderStage,
-            resourceInfo);
-    }
     if (format & SDL_GPU_SHADERFORMAT_DXIL) {
         return SDL_ShaderCross_INTERNAL_CreateShaderFromDXC(
             device,
@@ -919,6 +910,15 @@ static void *SDL_ShaderCross_INTERNAL_CreateShaderFromHLSL(
             shaderStage,
             resourceInfo,
             false);
+    }
+    if (SDL_D3DCompile != NULL && (format & SDL_GPU_SHADERFORMAT_DXBC)) {
+        return SDL_ShaderCross_INTERNAL_CreateShaderFromDXBC(
+            device,
+            hlslSource,
+            entrypoint,
+            includeDir,
+            shaderStage,
+            resourceInfo);
     }
     if (format & SDL_GPU_SHADERFORMAT_SPIRV) {
         return SDL_ShaderCross_INTERNAL_CreateShaderFromDXC(

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -557,8 +557,7 @@ void *SDL_ShaderCross_CompileDXILFromHLSL(
         spirv,
         spirvSize,
         entrypoint,
-        shaderStage,
-        SDL_SHADERCROSS_SHADERMODEL_6_0);
+        shaderStage);
 
     SDL_free(spirv);
     if (translatedSource == NULL) {
@@ -802,9 +801,7 @@ void *SDL_ShaderCross_CompileDXBCFromHLSL(
         spirv,
         spirv_size,
         entrypoint,
-        shaderStage,
-        SDL_SHADERCROSS_SHADERMODEL_5_1
-    );
+        shaderStage);
     SDL_free(spirv);
 
     if (transpiledSource == NULL) {
@@ -1680,23 +1677,11 @@ void *SDL_ShaderCross_TranspileHLSLFromSPIRV(
     const Uint8 *bytecode,
     size_t bytecodeSize,
     const char *entrypoint,
-    SDL_ShaderCross_ShaderStage shaderStage,
-    SDL_ShaderCross_ShaderModel shaderModel)
+    SDL_ShaderCross_ShaderStage shaderStage)
 {
-    unsigned int spirv_cross_shader_model = 0;
-
-    if (shaderModel == SDL_SHADERCROSS_SHADERMODEL_5_1) {
-        spirv_cross_shader_model = 51;
-    } else if (shaderModel == SDL_SHADERCROSS_SHADERMODEL_6_0) {
-        spirv_cross_shader_model = 60;
-    } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "Invalid shader profile!");
-        return NULL;
-    }
-
     SPIRVTranspileContext *context = SDL_ShaderCross_INTERNAL_TranspileFromSPIRV(
         SPVC_BACKEND_HLSL,
-        spirv_cross_shader_model,
+        60,
         shaderStage,
         bytecode,
         bytecodeSize,

--- a/src/SDL_gpu_shadercross.c
+++ b/src/SDL_gpu_shadercross.c
@@ -23,10 +23,6 @@
 #include <SDL3/SDL_loadso.h>
 #include <SDL3/SDL_log.h>
 
-#ifndef SDL_GPU_SHADERCROSS_DXC
-#define SDL_GPU_SHADERCROSS_DXC 1
-#endif /* SDL_GPU_SHADERCROSS_DXC */
-
 /* Win32 Type Definitions */
 
 typedef int HRESULT;

--- a/src/cli.c
+++ b/src/cli.c
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
                     &bytecodeSize);
                 SDL_WriteIO(outputIO, buffer, bytecodeSize);
                 SDL_free(buffer);
-                return 0;
+                break;
             }
 
             case SHADERFORMAT_HLSL: {

--- a/src/cli.c
+++ b/src/cli.c
@@ -42,7 +42,7 @@ void print_help(void)
     SDL_Log("  %-*s %s", column_width, "-d | --dest <value>", "Destination format. May be inferred from the filename. Values: [DXBC, DXIL, MSL, SPIRV, HLSL]");
     SDL_Log("  %-*s %s", column_width, "-t | --stage <value>", "Shader stage. May be inferred from the filename. Values: [vertex, fragment, compute]");
     SDL_Log("  %-*s %s", column_width, "-e | --entrypoint <value>", "Entrypoint function name. Default: \"main\".");
-    SDL_Log("  %-*s %s", column_width, "-m | --shadermodel <value>", "HLSL Shader Model. Only used with HLSL destination. Values: [5.0, 6.0]");
+    SDL_Log("  %-*s %s", column_width, "-m | --shadermodel <value>", "HLSL Shader Model. Only used with HLSL destination. Values: [5.1, 6.0]");
     SDL_Log("  %-*s %s", column_width, "-I | --include <value>", "HLSL include directory. Only used with HLSL source. Optional.");
     SDL_Log("  %-*s %s", column_width, "-o | --output <value>", "Output file.");
 }
@@ -156,8 +156,8 @@ int main(int argc, char *argv[])
                     return 1;
                 }
                 i += 1;
-                if (SDL_strcmp(argv[i], "5.0") == 0) {
-                    shaderModel = SDL_SHADERCROSS_SHADERMODEL_5_0;
+                if (SDL_strcmp(argv[i], "5.1") == 0) {
+                    shaderModel = SDL_SHADERCROSS_SHADERMODEL_5_1;
                     shaderModelValid = true;
                 } else if (SDL_strcmp(argv[i], "6.0") == 0) {
                     shaderModel = SDL_SHADERCROSS_SHADERMODEL_6_0;


### PR DESCRIPTION
Now that D3D11 is removed from SDL GPU and DXBC support is added to the D3D12 backend, we can make DXC usage optional. Disabling DXC causes HLSL -> DXIL and HLSL -> SPIR-V compilation pathways to return an error. All SPIRV-Cross pathways will continue to function normally and every backend can still have shaders built for it via SPIR-V source (as long as D3DCompile is available for HLSL -> DXBC).

Resolves #52 